### PR TITLE
Fix #103 No longer lowercase case class names in derived sealed trait codecs

### DIFF
--- a/modules/annotations/shared/src/test/scala/io/circe/derivation/annotations/JsonCodecADTSpec.scala
+++ b/modules/annotations/shared/src/test/scala/io/circe/derivation/annotations/JsonCodecADTSpec.scala
@@ -37,15 +37,15 @@ class JsonCodecADTSpec extends WordSpec with Matchers {
     "serialize default" in {
       val a1: ADT1 = ADT1A(1)
 
-      a1.asJson.pretty(printer) should be("""{"adt1a":{"a":1}}""")
-      parse("""{"adt1a":{"a":1}}""").right.get.as[ADT1] should be(
+      a1.asJson.pretty(printer) should be("""{"ADT1A":{"a":1}}""")
+      parse("""{"ADT1A":{"a":1}}""").right.get.as[ADT1] should be(
         Right(a1)
       )
 
       val b1: ADT1 = ADT1B(1)
 
-      b1.asJson.pretty(printer) should be("""{"adt1b":{"b":1}}""")
-      parse("""{"adt1b":{"b":1}}""").right.get.as[ADT1] should be(
+      b1.asJson.pretty(printer) should be("""{"ADT1B":{"b":1}}""")
+      parse("""{"ADT1B":{"b":1}}""").right.get.as[ADT1] should be(
         Right(b1)
       )
     }
@@ -53,27 +53,27 @@ class JsonCodecADTSpec extends WordSpec with Matchers {
     "serialize discriminator custom fieldname" in {
       val a1: ADT1Custom = ADT1CustomA(1)
 
-      a1.asJson.pretty(printer) should be("""{"a":1,"_type":"adt1customa"}""")
-      parse("""{"a":1,"_type":"adt1customa"}""").right.get.as[ADT1Custom] should be(Right(a1))
+      a1.asJson.pretty(printer) should be("""{"a":1,"_type":"ADT1CustomA"}""")
+      parse("""{"a":1,"_type":"ADT1CustomA"}""").right.get.as[ADT1Custom] should be(Right(a1))
 
       val b1: ADT1Custom = ADT1CustomB(1)
 
-      b1.asJson.pretty(printer) should be("""{"b":1,"_type":"adt1customb"}""")
-      parse("""{"b":1,"_type":"adt1customb"}""").right.get.as[ADT1Custom] should be(Right(b1))
+      b1.asJson.pretty(printer) should be("""{"b":1,"_type":"ADT1CustomB"}""")
+      parse("""{"b":1,"_type":"ADT1CustomB"}""").right.get.as[ADT1Custom] should be(Right(b1))
     }
 
     "serialize discriminator typed" in {
       val a1: ADTTyped = ADTTypedA(1)
 
-      a1.asJson.pretty(printer) should be("""{"adttypeda":{"a":1}}""")
-      parse("""{"adttypeda":{"a":1}}""").right.get.as[ADTTyped] should be(
+      a1.asJson.pretty(printer) should be("""{"ADTTypedA":{"a":1}}""")
+      parse("""{"ADTTypedA":{"a":1}}""").right.get.as[ADTTyped] should be(
         Right(a1)
       )
 
       val b1: ADTTyped = ADTTypedB(1)
 
-      b1.asJson.pretty(printer) should be("""{"adttypedb":{"b":1}}""")
-      parse("""{"adttypedb":{"b":1}}""").right.get.as[ADTTyped] should be(
+      b1.asJson.pretty(printer) should be("""{"ADTTypedB":{"b":1}}""")
+      parse("""{"ADTTypedB":{"b":1}}""").right.get.as[ADTTyped] should be(
         Right(b1)
       )
     }

--- a/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
+++ b/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
@@ -16,6 +16,7 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
   private[this] val trueExpression = c.Expr[Boolean](q"true")
 
   private[this] def failWithMessage(message: String): Nothing = c.abort(c.enclosingPosition, message)
+  private[this] def nameOf(s: Symbol): String = s.asClass.name.decodedName.toString.trim
 
   private[this] case class Instance(tc: Type, tpe: Type, name: TermName) {
     def resolve(): Tree = c.inferImplicitValue(appliedType(tc, List(tpe))) match {
@@ -319,14 +320,14 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
 
     val objectWrapperCases: List[Tree] = subclasses.map { s =>
       val value =
-        Literal(Constant(s.asClass.name.decodedName.toString.toLowerCase()))
+        Literal(Constant(nameOf(s)))
 
       cq"""$value => c.get($value)(_root_.io.circe.Decoder[${s.asType}]).asInstanceOf[_root_.io.circe.Decoder.Result[$tpe]]"""
     }.toList
 
     val discriminatorCases: List[Tree] = subclasses.map { s =>
       val value =
-        Literal(Constant(s.asClass.name.decodedName.toString.toLowerCase()))
+        Literal(Constant(nameOf(s)))
 
       cq"""$value => _root_.io.circe.Decoder[${s.asType}].map[$tpe](_root_.scala.Predef.identity)"""
     }.toList
@@ -599,7 +600,7 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
 
     val encoderCases = subclasses.map { s =>
       val subTpe = s.asClass.toType
-      val name = s.asClass.name.decodedName.toString.toLowerCase
+      val name = nameOf(s)
 
       cq"""value: $subTpe =>
         val encoded = _root_.io.circe.Encoder.AsObject[$subTpe].encodeObject(value)
@@ -686,21 +687,21 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
 
     val objectWrapperCases: List[Tree] = subclasses.map { s =>
       val value =
-        Literal(Constant(s.asClass.name.decodedName.toString.toLowerCase()))
+        Literal(Constant(nameOf(s)))
 
       cq"""$value => c.get($value)(_root_.io.circe.Decoder[${s.asType}]).asInstanceOf[_root_.io.circe.Decoder.Result[$tpe]]"""
     }.toList
 
     val discriminatorCases: List[Tree] = subclasses.map { s =>
       val value =
-        Literal(Constant(s.asClass.name.decodedName.toString.toLowerCase()))
+        Literal(Constant(nameOf(s)))
 
       cq"""$value => _root_.io.circe.Decoder[${s.asType}].map[$tpe](_root_.scala.Predef.identity)"""
     }.toList
 
     val encoderCases = subclasses.map { s =>
       val subTpe = s.asClass.toType
-      val name = s.asClass.name.decodedName.toString.toLowerCase
+      val name = nameOf(s)
 
       cq"""value: $subTpe =>
         val encoded = _root_.io.circe.Encoder.AsObject[$subTpe].encodeObject(value)

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/DerivationSuite.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/DerivationSuite.scala
@@ -46,19 +46,34 @@ object DerivationSuiteCodecs extends Serializable {
   implicit val encodeWithDefaults: Encoder[WithDefaults] = deriveEncoder(identity, None)
   val codecForWithDefaults: Codec[WithDefaults] = deriveCodec(identity, true, None)
 
-  val typeField = Some("_type")
-  implicit val decodeAdtFoo: Decoder[AdtFoo] = deriveDecoder(identity, false, typeField)
-  implicit val encodeAdtFoo: Encoder.AsObject[AdtFoo] = deriveEncoder(identity, typeField)
+  implicit val decodeAdtFoo: Decoder[AdtFoo] = deriveDecoder
+  implicit val encodeAdtFoo: Encoder.AsObject[AdtFoo] = deriveEncoder
 
-  implicit val decodeAdtBar: Decoder[AdtBar] = deriveDecoder(identity, false, typeField)
-  implicit val encodeAdtBar: Encoder.AsObject[AdtBar] = deriveEncoder(identity, typeField)
+  implicit val decodeAdtBar: Decoder[AdtBar] = deriveDecoder
+  implicit val encodeAdtBar: Encoder.AsObject[AdtBar] = deriveEncoder
 
-  implicit val decodeAdtQux: Decoder[AdtQux.type] = deriveDecoder(identity, false, typeField)
-  implicit val encodeAdtQux: Encoder.AsObject[AdtQux.type] = deriveEncoder(identity, typeField)
+  implicit val decodeAdtQux: Decoder[AdtQux.type] = deriveDecoder
+  implicit val encodeAdtQux: Encoder.AsObject[AdtQux.type] = deriveEncoder
 
-  implicit val decodeAdt: Decoder[Adt] = deriveDecoder(identity, false, typeField)
-  implicit val encodeAdt: Encoder.AsObject[Adt] = deriveEncoder(identity, typeField)
-  val codecForAdt: Codec[Adt] = deriveCodec(identity, false, typeField)
+  implicit val decodeAdt: Decoder[Adt] = deriveDecoder
+  implicit val encodeAdt: Encoder.AsObject[Adt] = deriveEncoder
+  val codecForAdt: Codec[Adt] = deriveCodec
+
+  object discriminator {
+    val typeField = Some("_type")
+    implicit val decodeAdtFoo: Decoder[AdtFoo] = deriveDecoder(identity, false, typeField)
+    implicit val encodeAdtFoo: Encoder.AsObject[AdtFoo] = deriveEncoder(identity, typeField)
+
+    implicit val decodeAdtBar: Decoder[AdtBar] = deriveDecoder(identity, false, typeField)
+    implicit val encodeAdtBar: Encoder.AsObject[AdtBar] = deriveEncoder(identity, typeField)
+
+    implicit val decodeAdtQux: Decoder[AdtQux.type] = deriveDecoder(identity, false, typeField)
+    implicit val encodeAdtQux: Encoder.AsObject[AdtQux.type] = deriveEncoder(identity, typeField)
+
+    implicit val decodeAdt: Decoder[Adt] = deriveDecoder(identity, false, typeField)
+    implicit val encodeAdt: Encoder.AsObject[Adt] = deriveEncoder(identity, typeField)
+    val codecForAdt: Codec[Adt] = deriveCodec(identity, false, typeField)
+  }
 }
 
 class DerivationSuite extends CirceSuite {
@@ -179,6 +194,16 @@ class DerivationSuite extends CirceSuite {
   )
 
   checkLaws(
+    "CodecAgreement[Adt]",
+    CodecAgreementTests[Adt](
+      GenericAutoCodecs.decodeAdt,
+      GenericAutoCodecs.encodeAdt,
+      decodeAdt,
+      encodeAdt
+    ).codecAgreement
+  )
+
+  checkLaws(
     "CodecAgreementWithCodec[Foo]",
     CodecAgreementTests[Foo](
       codecForFoo,
@@ -261,10 +286,10 @@ class DerivationSuite extends CirceSuite {
   checkLaws(
     "CodecAgreementWithCodec[Adt]",
     CodecAgreementTests[Adt](
-      codecForAdt,
-      codecForAdt,
-      decodeAdt,
-      encodeAdt
+      discriminator.codecForAdt,
+      discriminator.codecForAdt,
+      discriminator.decodeAdt,
+      discriminator.encodeAdt
     ).codecAgreement
   )
 

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/GenericAutoCodecs.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/GenericAutoCodecs.scala
@@ -13,6 +13,8 @@ object GenericAutoCodecs {
   implicit val encodeBaz: Encoder.AsObject[Baz] = genericDeriveEncoder
   implicit def decodeQux[A: Decoder]: Decoder[Qux[A]] = genericDeriveDecoder
   implicit def encodeQux[A: Encoder]: Encoder.AsObject[Qux[A]] = genericDeriveEncoder
+  implicit val decodeAdt: Decoder[Adt] = genericDeriveDecoder
+  implicit val encodeAdt: Encoder.AsObject[Adt] = genericDeriveEncoder
 
   implicit val decodeSimpleClass: Decoder[SimpleClass] = genericDeriveDecoder
   implicit val encodeSimpleClass: Encoder[SimpleClass] = genericDeriveEncoder


### PR DESCRIPTION
Same incantation as in [LabelledGeneric](https://github.com/milessabin/shapeless/blob/ab5a1a6bb1e01e13fd417e0ee0d8726d54344d84/core/src/main/scala/shapeless/generic.scala#L473), so should be compatible with `circe-generic`; also added a test.