### PR TITLE
fix: defaults for null values

### DIFF
--- a/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
+++ b/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
@@ -768,7 +768,7 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
         {
           val field = c.downField($realFieldName)
 
-          if (field.failed && $useDefaults) {
+          if ((field.failed || field.focus.exists(_.isNull)) && $useDefaults) {
             _root_.scala.Right(${member.default.get})
           } else {
             ${repr.decoder(member.tpe).name}.tryDecode(field)

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/DerivationSuite.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/DerivationSuite.scala
@@ -299,10 +299,13 @@ class DerivationSuite extends CirceSuite {
 
     val j1 = Json.obj("i" := 0)
     val j2 = Json.obj("i" := 0, "k" := List.empty[String])
+    val j3 = Json.obj("i" := 0, "k" := Json.Null)
 
     assert(decodeWithDefaults.decodeJson(j1) === expectedBothDefaults)
     assert(codecForWithDefaults.decodeJson(j1) === expectedBothDefaults)
     assert(decodeWithDefaults.decodeJson(j2) === expectedOneDefault)
     assert(codecForWithDefaults.decodeJson(j2) === expectedOneDefault)
+    assert(decodeWithDefaults.decodeJson(j3) === expectedBothDefaults)
+    assert(codecForWithDefaults.decodeJson(j3) === expectedBothDefaults)
   }
 }


### PR DESCRIPTION
behaviour differs from circe-generic-extras
case classes should be constructed with default values when cursor
points to JNull

https://github.com/circe/circe-derivation/issues/115