### PR TITLE
Fix default decoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,6 +173,7 @@ lazy val examples = crossProject(JSPlatform, JVMPlatform)
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
+      "io.circe" %%% "circe-testing" % circeVersion,
       "org.scalacheck" %%% "scalacheck" % scalaCheckVersion,
       "org.typelevel" %%% "cats-core" % catsVersion
     )

--- a/examples/src/main/scala/io/circe/examples/WithJson.scala
+++ b/examples/src/main/scala/io/circe/examples/WithJson.scala
@@ -1,0 +1,21 @@
+package io.circe.examples
+
+import cats.kernel.Eq
+import io.circe.Json
+import io.circe.testing.instances._
+import org.scalacheck.Arbitrary
+
+case class WithJson(i: Int, j: Int = 1, embedded: Json = Json.obj(), k: List[String] = List(""))
+
+object WithJson {
+  implicit val arbitraryWithDefaults: Arbitrary[WithJson] = Arbitrary(
+    for {
+      i <- Arbitrary.arbitrary[Int]
+      j <- Arbitrary.arbitrary[Int]
+      e <- Arbitrary.arbitrary[Json]
+      k <- Arbitrary.arbitrary[List[String]]
+    } yield WithJson(i, j, e, k)
+  )
+
+  implicit val eqWithJson: Eq[WithJson] = Eq.fromUniversalEquals
+}


### PR DESCRIPTION
This PR fixes one issue that slipped in in #117 and one piece of #115 that wasn't addressed in #117. The first issue involves `Json` members with default values (thanks @bastewart for reporting this):

```scala
scala> import io.circe.Json, io.circe.literal._
import io.circe.Json
import io.circe.literal._

scala> case class Foo(value: Json = Json.obj())
defined class Foo

scala> io.circe.derivation.deriveDecoder[Foo].decodeJson(json"""{"value": null}""")
res0: io.circe.Decoder.Result[Foo] =
Right(Foo({

}))
```
The equivalently configured `Decoder` from generic-extras will preserve the `null` as expected.

The other issue is that error-accumulating decoding also differed from generic-extras in that default values weren't used when there's a `null`:

```scala
scala> import io.circe.derivation.deriveDecoder, io.circe.jawn.decodeAccumulating
import io.circe.derivation.deriveDecoder
import io.circe.jawn.decodeAccumulating

scala> case class MyData(strings: Seq[String] = Nil)
defined class MyData

scala> decodeAccumulating[MyData]("""{"strings":null}""")(deriveDecoder)
res0: cats.data.ValidatedNel[io.circe.Error,MyData] = Invalid(NonEmptyList(DecodingFailure(C[A], List(DownField(strings)))))
```
This PR fixes both issues (and adds tests). Unfortunately we have to add a couple of methods to the public API that should be private, but the alternative was introducing something like a runtime `DerivedDecoder` class, which so far we've avoided.
