### PR TITLE
Suppress unused variable warnings

### DIFF
--- a/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
+++ b/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
@@ -831,7 +831,7 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
           ${repr.decoder(member.tpe).name}.tryDecode(field) match {
             case r @ _root_.scala.Right(_) if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNone(r) => r
             case l @ _root_.scala.Left(_) if field.succeeded && !field.focus.exists(_.isNull) => l
-            case r => _root_.scala.Right($defaultValue)
+            case r @ _ => _root_.scala.Right($defaultValue)
           }
         }
         """
@@ -858,7 +858,7 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
             case v @ _root_.cats.data.Validated.Valid(_)
               if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNoneAccumulating(v) => v
             case i @ _root_.cats.data.Validated.Invalid(_) if field.succeeded && !field.focus.exists(_.isNull) => i
-            case v => _root_.cats.data.Validated.Valid($defaultValue)
+            case v @ _ => _root_.cats.data.Validated.Valid($defaultValue)
           }
         }
         """


### PR DESCRIPTION
Currently, when compiling a project with unused variable warnings (and fatal warnings), we get:

```
[error]      pattern var v in value res1 is never used; `v@_` suppresses this warning
[error]      L12:@JsonCodec(Configuration.decodeOnly)
[error]      L12: ^
```

Likewise:

```
[error]      pattern var r in value res is never used; `r@_` suppresses this warning
[error]      L12:@JsonCodec(Configuration.decodeOnly)
[error]      L12: ^
```

This commit fixes that.