### PR TITLE
Recurse on sealed trait's subclasses to match circe-generic

### DIFF
--- a/examples/src/main/scala/io/circe/examples/NestedAdt.scala
+++ b/examples/src/main/scala/io/circe/examples/NestedAdt.scala
@@ -1,0 +1,25 @@
+package io.circe.examples
+
+import cats.kernel.Eq
+import org.scalacheck.{ Arbitrary, Gen }
+
+sealed trait NestedAdt
+sealed trait NestedAdt1 extends NestedAdt
+sealed trait NestedAdt2 extends NestedAdt
+final case class NestedAdtFoo(i: Int, s: String = "abc") extends NestedAdt1 with NestedAdt2
+case class NestedAdtBar(xs: List[Boolean]) extends NestedAdt
+case object NestedAdtQux extends NestedAdt1
+
+object NestedAdt {
+  implicit val arbitraryNestedAdt: Arbitrary[NestedAdt] = Arbitrary(
+    Gen.oneOf(
+      for {
+        i <- Arbitrary.arbitrary[Int]
+        s <- Arbitrary.arbitrary[String]
+      } yield NestedAdtFoo(i, s),
+      Arbitrary.arbitrary[List[Boolean]].map(NestedAdtBar(_)),
+      Gen.const(NestedAdtQux)
+    )
+  )
+  implicit val eqNestedAdt: Eq[NestedAdt] = Eq.fromUniversalEquals
+}

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/GenericAutoCodecs.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/GenericAutoCodecs.scala
@@ -15,6 +15,8 @@ object GenericAutoCodecs {
   implicit def encodeQux[A: Encoder]: Encoder.AsObject[Qux[A]] = genericDeriveEncoder
   implicit val decodeAdt: Decoder[Adt] = genericDeriveDecoder
   implicit val encodeAdt: Encoder.AsObject[Adt] = genericDeriveEncoder
+  implicit val decodeNestedAdt: Decoder[NestedAdt] = genericDeriveDecoder
+  implicit val encodeNestedAdt: Encoder.AsObject[NestedAdt] = genericDeriveEncoder
 
   implicit val decodeSimpleClass: Decoder[SimpleClass] = genericDeriveDecoder
   implicit val encodeSimpleClass: Encoder[SimpleClass] = genericDeriveEncoder


### PR DESCRIPTION
Fixes #133 

Using the same example:

```scala
import io.circe.{Codec, derivation}

sealed trait Outer
sealed trait Nested1 extends Outer
sealed trait Nested2 extends Outer
final case class Branch(i: Int) extends Nested1 with Nested2
object Branch { implicit val codec: Codec.AsObject[Branch] = derivation.deriveCodec }

println(derivation.deriveCodec[Outer].apply(Branch(1)).noSpaces)
// {"Branch":{"i":1}}
```

This has the side effect of not requiring `Codec`s for `Nested1` and `Nested2` when deriving a codec for `Outer`. I don't think that's a problem, just calling it out as a change in behavior.