### PR TITLE
Remove unused vars

### DIFF
--- a/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
+++ b/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
@@ -848,7 +848,7 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
           ${repr.decoder(member.tpe).name}.tryDecode(field) match {
             case r @ _root_.scala.Right(_) if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNone(r) => r
             case l @ _root_.scala.Left(_) if field.succeeded && !field.focus.exists(_.isNull) => l
-            case r @ _ => _root_.scala.Right($defaultValue)
+            case _ => _root_.scala.Right($defaultValue)
           }
         }
         """
@@ -875,7 +875,7 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
             case v @ _root_.cats.data.Validated.Valid(_)
               if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNoneAccumulating(v) => v
             case i @ _root_.cats.data.Validated.Invalid(_) if field.succeeded && !field.focus.exists(_.isNull) => i
-            case v @ _ => _root_.cats.data.Validated.Valid($defaultValue)
+            case _ => _root_.cats.data.Validated.Valid($defaultValue)
           }
         }
         """


### PR DESCRIPTION
These are triggering warnings for `var v is never used` warnings in our build and don't seem to be used. 

I swear there was an issue about this (maybe it was on a different circe package)

EDIT: Found it, the comments where on the PR of the last fix https://github.com/circe/circe-derivation/pull/189