### PR TITLE
Respect use defaults

### DIFF
--- a/examples/src/main/scala/io/circe/examples/WithoutDefaults.scala
+++ b/examples/src/main/scala/io/circe/examples/WithoutDefaults.scala
@@ -1,0 +1,18 @@
+package io.circe.examples
+
+import cats.kernel.Eq
+import org.scalacheck.Arbitrary
+
+case class WithoutDefaults(i: Int, j: Int = 1, k: Option[Int] = Some(5))
+
+object WithoutDefaults {
+  implicit val arbitraryWithoutDefaults: Arbitrary[WithoutDefaults] = Arbitrary(
+    for {
+      i <- Arbitrary.arbitrary[Int]
+      j <- Arbitrary.arbitrary[Int]
+      k <- Arbitrary.arbitrary[Option[Int]]
+    } yield WithoutDefaults(i, j, k)
+  )
+
+  implicit val eqWithoutDefaults: Eq[WithoutDefaults] = Eq.fromUniversalEquals
+}

--- a/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
+++ b/modules/derivation/shared/src/main/scala/io/circe/derivation/DerivationMacros.scala
@@ -839,10 +839,14 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
         {
           val field = c.downField($realFieldName)
 
-          ${repr.decoder(member.tpe).name}.tryDecode(field) match {
-            case r @ _root_.scala.Right(_) if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNone(r) => r
-            case l @ _root_.scala.Left(_) if field.succeeded && !field.focus.exists(_.isNull) => l
-            case _ => _root_.scala.Right($defaultValue)
+          if ($useDefaults) {
+            ${repr.decoder(member.tpe).name}.tryDecode(field) match {
+              case r @ _root_.scala.Right(_) if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNone(r) => r
+              case l @ _root_.scala.Left(_) if field.succeeded && !field.focus.exists(_.isNull) => l
+              case _ => _root_.scala.Right($defaultValue)
+            }
+          } else {
+            ${repr.decoder(member.tpe).name}.tryDecode(field)
           }
         }
         """
@@ -865,11 +869,15 @@ class DerivationMacros(val c: blackbox.Context) extends ScalaVersionCompat {
         {
           val field = c.downField($realFieldName)
 
-          ${repr.decoder(member.tpe).name}.tryDecodeAccumulating(field) match {
-            case v @ _root_.cats.data.Validated.Valid(_)
-              if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNoneAccumulating(v) => v
-            case i @ _root_.cats.data.Validated.Invalid(_) if field.succeeded && !field.focus.exists(_.isNull) => i
-            case _ => _root_.cats.data.Validated.Valid($defaultValue)
+          if ($useDefaults) {
+            ${repr.decoder(member.tpe).name}.tryDecodeAccumulating(field) match {
+              case v @ _root_.cats.data.Validated.Valid(_)
+                if !_root_.io.circe.derivation.DerivationMacros.isKeyMissingNoneAccumulating(v) => v
+              case i @ _root_.cats.data.Validated.Invalid(_) if field.succeeded && !field.focus.exists(_.isNull) => i
+              case _ => _root_.cats.data.Validated.Valid($defaultValue)
+            }
+          } else {
+            ${repr.decoder(member.tpe).name}.tryDecodeAccumulating(field)
           }
         }
         """


### PR DESCRIPTION
Currently the `useDefaults` parameter does nothing and defaults are always taken when the key is not present or is `null` in the Json. This PR changes the behavior so that when `useDefaults` is `false`, defaults are ignored, and an error will be raised for non-optional fields, or `None` will be used for optional fields.

Fixes: https://github.com/circe/circe-derivation/issues/297