### PR TITLE
Implement strict decoding

### DIFF
--- a/modules/annotations/shared/src/main/scala/io/circe/derivation/annotations/Configuration.scala
+++ b/modules/annotations/shared/src/main/scala/io/circe/derivation/annotations/Configuration.scala
@@ -25,6 +25,8 @@ sealed trait Configuration {
    */
   def transformConstructorNames: String => String
 
+  def strictDecoding: Boolean
+
   def useDefaults: Boolean
 
   def discriminator: Option[String]
@@ -67,7 +69,8 @@ object Configuration {
     transformMemberNames: String => String,
     transformConstructorNames: String => String,
     useDefaults: Boolean,
-    discriminator: Option[String]
+    discriminator: Option[String],
+    strictDecoding: Boolean = false
   ) extends Configuration {
 
     type Config = Codec
@@ -94,7 +97,8 @@ object Configuration {
     transformMemberNames: String => String,
     transformConstructorNames: String => String,
     useDefaults: Boolean,
-    discriminator: Option[String]
+    discriminator: Option[String],
+    strictDecoding: Boolean = false
   ) extends Configuration {
 
     type Config = DecodeOnly
@@ -119,7 +123,8 @@ object Configuration {
     transformMemberNames: String => String,
     transformConstructorNames: String => String,
     useDefaults: Boolean,
-    discriminator: Option[String]
+    discriminator: Option[String],
+    strictDecoding: Boolean = false
   ) extends Configuration {
 
     type Config = EncodeOnly

--- a/modules/annotations/shared/src/main/scala/io/circe/derivation/annotations/JsonCodec.scala
+++ b/modules/annotations/shared/src/main/scala/io/circe/derivation/annotations/JsonCodec.scala
@@ -65,11 +65,11 @@ private[derivation] final class GenericJsonCodecMacros(val c: blackbox.Context) 
     val Type = tq"$objName.type"
     val (decoder, encoder, codec) = (
       q"""implicit val $decoderName: $DecoderClass[$Type] =
-            _root_.io.circe.derivation.deriveDecoder[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator)""",
+            _root_.io.circe.derivation.deriveDecoder[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator, $cfgStrictDecoding)""",
       q"""implicit val $encoderName: $AsObjectEncoderClass[$Type] =
             _root_.io.circe.derivation.deriveEncoder[$Type]($transformNames, $cfgDiscriminator)""",
       q"""implicit val $codecName: $AsObjectCodecClass[$Type] =
-            _root_.io.circe.derivation.deriveCodec[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator)"""
+            _root_.io.circe.derivation.deriveCodec[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator, $cfgStrictDecoding)"""
     )
     codecType match {
       case JsonCodecType.Both               => codec
@@ -141,6 +141,8 @@ private[derivation] final class GenericJsonCodecMacros(val c: blackbox.Context) 
     q"$config.useDefaults"
   private[this] val cfgDiscriminator =
     q"$config.discriminator"
+  private[this] val cfgStrictDecoding =
+    q"$config.strictDecoding"
 
   private[this] def codec(clsDef: ClassDef): Tree = {
     val tpname = clsDef.name
@@ -153,11 +155,11 @@ private[derivation] final class GenericJsonCodecMacros(val c: blackbox.Context) 
       val Type = tpname
       (
         q"""implicit val $decoderName: $DecoderClass[$Type] =
-            _root_.io.circe.derivation.deriveDecoder[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator)""",
+            _root_.io.circe.derivation.deriveDecoder[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator, $cfgStrictDecoding)""",
         q"""implicit val $encoderName: $AsObjectEncoderClass[$Type] =
             _root_.io.circe.derivation.deriveEncoder[$Type]($transformNames, $cfgDiscriminator)""",
         q"""implicit val $codecName: $AsObjectCodecClass[$Type] =
-            _root_.io.circe.derivation.deriveCodec[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator)"""
+            _root_.io.circe.derivation.deriveCodec[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator, $cfgStrictDecoding)"""
       )
     } else {
       val tparamNames = tparams.map(_.name)
@@ -172,13 +174,13 @@ private[derivation] final class GenericJsonCodecMacros(val c: blackbox.Context) 
       val Type = tq"$tpname[..$tparamNames]"
       (
         q"""implicit def $decoderName[..$tparams](implicit ..$decodeParams): $DecoderClass[$Type] =
-           _root_.io.circe.derivation.deriveDecoder[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator)""",
+           _root_.io.circe.derivation.deriveDecoder[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator, $cfgStrictDecoding)""",
         q"""implicit def $encoderName[..$tparams](implicit ..$encodeParams): $AsObjectEncoderClass[$Type] =
            _root_.io.circe.derivation.deriveEncoder[$Type]($transformNames, $cfgDiscriminator)""",
         q"""implicit def $codecName[..$tparams](implicit
             ..${decodeParams ++ encodeParams}
           ): $AsObjectCodecClass[$Type] =
-            _root_.io.circe.derivation.deriveCodec[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator)"""
+            _root_.io.circe.derivation.deriveCodec[$Type]($transformNames, $cfgUseDefaults, $cfgDiscriminator, $cfgStrictDecoding)"""
       )
     }
     codecType match {

--- a/modules/derivation/shared/src/main/scala/io/circe/derivation/package.scala
+++ b/modules/derivation/shared/src/main/scala/io/circe/derivation/package.scala
@@ -10,7 +10,8 @@ package object derivation {
   final def deriveDecoder[A](
     transformNames: String => String,
     useDefaults: Boolean,
-    discriminator: Option[String]
+    discriminator: Option[String],
+    strictDecoding: Boolean
   ): Decoder[A] =
     macro DerivationMacros.materializeDecoderWithTransformNames[A]
 
@@ -29,7 +30,8 @@ package object derivation {
   final def deriveCodec[A](
     transformNames: String => String,
     useDefaults: Boolean,
-    discriminator: Option[String]
+    discriminator: Option[String],
+    strictDecoding: Boolean
   ): Codec.AsObject[A] =
     macro DerivationMacros.materializeCodecWithTransformNames[A]
 

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/DerivationSuite.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/DerivationSuite.scala
@@ -43,13 +43,13 @@ object DerivationSuiteCodecs extends Serializable {
   implicit val encodeCustomApplyParamTypesClass: Encoder[CustomApplyParamTypesClass] = deriveEncoder
   val codecForCustomApplyParamTypesClass: Codec[CustomApplyParamTypesClass] = deriveCodec
 
-  implicit val decodeWithDefaults: Decoder[WithDefaults] = deriveDecoder(identity, true, None)
+  implicit val decodeWithDefaults: Decoder[WithDefaults] = deriveDecoder(identity, true, None, false)
   implicit val encodeWithDefaults: Encoder[WithDefaults] = deriveEncoder(identity, None)
-  val codecForWithDefaults: Codec[WithDefaults] = deriveCodec(identity, true, None)
+  val codecForWithDefaults: Codec[WithDefaults] = deriveCodec(identity, true, None, false)
 
-  implicit val decodeWithJson: Decoder[WithJson] = deriveDecoder(identity, true, None)
+  implicit val decodeWithJson: Decoder[WithJson] = deriveDecoder(identity, true, None, false)
   implicit val encodeWithJson: Encoder[WithJson] = deriveEncoder(identity, None)
-  val codecForWithJson: Codec[WithJson] = deriveCodec(identity, true, None)
+  val codecForWithJson: Codec[WithJson] = deriveCodec(identity, true, None, false)
 
   implicit val decodeAdtFoo: Decoder[AdtFoo] = deriveDecoder
   implicit val encodeAdtFoo: Encoder.AsObject[AdtFoo] = deriveEncoder
@@ -79,31 +79,31 @@ object DerivationSuiteCodecs extends Serializable {
 
   object discriminator {
     val typeField = Some("_type")
-    implicit val decodeAdtFoo: Decoder[AdtFoo] = deriveDecoder(identity, false, typeField)
+    implicit val decodeAdtFoo: Decoder[AdtFoo] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeAdtFoo: Encoder.AsObject[AdtFoo] = deriveEncoder(identity, typeField)
 
-    implicit val decodeAdtBar: Decoder[AdtBar] = deriveDecoder(identity, false, typeField)
+    implicit val decodeAdtBar: Decoder[AdtBar] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeAdtBar: Encoder.AsObject[AdtBar] = deriveEncoder(identity, typeField)
 
-    implicit val decodeAdtQux: Decoder[AdtQux.type] = deriveDecoder(identity, false, typeField)
+    implicit val decodeAdtQux: Decoder[AdtQux.type] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeAdtQux: Encoder.AsObject[AdtQux.type] = deriveEncoder(identity, typeField)
 
-    implicit val decodeAdt: Decoder[Adt] = deriveDecoder(identity, false, typeField)
+    implicit val decodeAdt: Decoder[Adt] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeAdt: Encoder.AsObject[Adt] = deriveEncoder(identity, typeField)
-    val codecForAdt: Codec[Adt] = deriveCodec(identity, false, typeField)
+    val codecForAdt: Codec[Adt] = deriveCodec(identity, false, typeField, false)
 
-    implicit val decodeNestedAdtFoo: Decoder[NestedAdtFoo] = deriveDecoder(identity, false, typeField)
+    implicit val decodeNestedAdtFoo: Decoder[NestedAdtFoo] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeNestedAdtFoo: Encoder.AsObject[NestedAdtFoo] = deriveEncoder(identity, typeField)
 
-    implicit val decodeNestedAdtBar: Decoder[NestedAdtBar] = deriveDecoder(identity, false, typeField)
+    implicit val decodeNestedAdtBar: Decoder[NestedAdtBar] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeNestedAdtBar: Encoder.AsObject[NestedAdtBar] = deriveEncoder(identity, typeField)
 
-    implicit val decodeNestedAdtQux: Decoder[NestedAdtQux.type] = deriveDecoder(identity, false, typeField)
+    implicit val decodeNestedAdtQux: Decoder[NestedAdtQux.type] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeNestedAdtQux: Encoder.AsObject[NestedAdtQux.type] = deriveEncoder(identity, typeField)
 
-    implicit val decodeNestedAdt: Decoder[NestedAdt] = deriveDecoder(identity, false, typeField)
+    implicit val decodeNestedAdt: Decoder[NestedAdt] = deriveDecoder(identity, false, typeField, false)
     implicit val encodeNestedAdt: Encoder.AsObject[NestedAdt] = deriveEncoder(identity, typeField)
-    val codecForNestedAdt: Codec[NestedAdt] = deriveCodec(identity, false, typeField)
+    val codecForNestedAdt: Codec[NestedAdt] = deriveCodec(identity, false, typeField, false)
   }
 }
 

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/StrictDecodingExample.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/StrictDecodingExample.scala
@@ -1,10 +1,10 @@
 package io.circe.derivation
 
 import cats.kernel.Eq
-import io.circe.{ Codec, Decoder, Encoder }
+import io.circe.{Codec, Decoder, Encoder}
 import org.scalacheck.Arbitrary
 
-object TransformMemberNamesExample {
+object StrictDecodingExample {
   case class User(firstName: String, lastName: String, role: Role, address: Address)
 
   object User {
@@ -20,8 +20,8 @@ object TransformMemberNamesExample {
     implicit val eqUser: Eq[User] = Eq.fromUniversalEquals
 
     implicit val encodeUser: Encoder[User] = deriveEncoder(renaming.snakeCase, None)
-    implicit val decodeUser: Decoder[User] = deriveDecoder(renaming.snakeCase, true, None, false)
-    val codecForUser: Codec[User] = deriveCodec(renaming.snakeCase, true, None, false)
+    implicit val decodeUser: Decoder[User] = deriveDecoder(renaming.snakeCase, true, None, true)
+    val codecForUser: Codec[User] = deriveCodec(renaming.snakeCase, true, None, true)
   }
 
   case class Role(title: String)
@@ -31,7 +31,7 @@ object TransformMemberNamesExample {
     implicit val eqRole: Eq[Role] = Eq.fromUniversalEquals
 
     implicit val encodeRole: Encoder[Role] = deriveEncoder(_.toUpperCase, None)
-    implicit val decodeRole: Decoder[Role] = deriveDecoder(_.toUpperCase, true, None, false)
+    implicit val decodeRole: Decoder[Role] = deriveDecoder(_.toUpperCase, true, None, true)
   }
 
   case class Address(number: Int, street: String, city: String)
@@ -50,23 +50,6 @@ object TransformMemberNamesExample {
     implicit val encodeAddress: Encoder[Address] =
       deriveEncoder(renaming.replaceWith("number" -> "#"), None)
     implicit val decodeAddress: Decoder[Address] =
-      deriveDecoder(renaming.replaceWith("number" -> "#"), true, None, false)
-  }
-
-  case class Abc(a: String, b: String, c: String)
-
-  object Abc {
-    implicit val arbitraryAbc: Arbitrary[Abc] = Arbitrary(
-      for {
-        a <- Arbitrary.arbitrary[String]
-        b <- Arbitrary.arbitrary[String]
-        c <- Arbitrary.arbitrary[String]
-      } yield Abc(a, b, c)
-    )
-
-    implicit val eqAbc: Eq[Abc] = Eq.fromUniversalEquals
-
-    implicit val encodeAbc: Encoder[Abc] = deriveEncoder(_ => "x", None)
-    implicit val decodeAbc: Decoder[Abc] = deriveDecoder(_ => "x", true, None, false)
+      deriveDecoder(renaming.replaceWith("number" -> "#"), true, None, true)
   }
 }

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/StrictDecodingSuite.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/StrictDecodingSuite.scala
@@ -1,0 +1,130 @@
+package io.circe.derivation
+
+import cats.data.{NonEmptyList, Validated}
+import io.circe.examples.{Bar, Baz, Foo, Qux}
+import io.circe.{Codec, CursorOp, Decoder, DecodingFailure, Encoder, Json}
+import io.circe.testing.CodecTests
+
+object StrictDecodingSuiteCodecs extends Serializable {
+  implicit val decodeFoo: Decoder[Foo] = deriveDecoder(renaming.snakeCase, true, None, true)
+  implicit val encodeFoo: Encoder.AsObject[Foo] = deriveEncoder(renaming.snakeCase, None)
+  val codecForFoo: Codec.AsObject[Foo] = deriveCodec(renaming.snakeCase, true, None, true)
+
+  implicit val decodeBar: Decoder[Bar] = deriveDecoder(renaming.snakeCase, true, None, true)
+  implicit val encodeBar: Encoder.AsObject[Bar] = deriveEncoder(renaming.snakeCase, None)
+  val codecForBar: Codec.AsObject[Bar] = deriveCodec(renaming.snakeCase, true, None, true)
+
+  implicit val decodeBaz: Decoder[Baz] = deriveDecoder(renaming.snakeCase, true, None, true)
+  implicit val encodeBaz: Encoder.AsObject[Baz] = deriveEncoder(renaming.snakeCase, None)
+  val codecForBaz: Codec.AsObject[Baz] = deriveCodec(renaming.snakeCase, true, None, true)
+
+  implicit def decodeQux[A: Decoder]: Decoder[Qux[A]] =
+    deriveDecoder(renaming.replaceWith("aa" -> "1", "bb" -> "2"), true, None, true)
+  implicit def encodeQux[A: Encoder]: Encoder.AsObject[Qux[A]] =
+    deriveEncoder(renaming.replaceWith("aa" -> "1", "bb" -> "2"), None)
+  def codecForQux[A: Decoder: Encoder]: Codec.AsObject[Qux[A]] = deriveCodec(
+    renaming.replaceWith("aa" -> "1", "bb" -> "2"),
+    true,
+    None,
+    true
+  )
+}
+
+class StrictDecodingSuite extends CirceSuite {
+  import StrictDecodingExample._
+  import StrictDecodingSuiteCodecs._
+
+  checkAll("Codec[Foo]", CodecTests[Foo].codec)
+  checkAll("Codec[Foo] via Codec", CodecTests[Foo](codecForFoo, codecForFoo).codec)
+  checkAll("Codec[Bar]", CodecTests[Bar].codec)
+  checkAll("Codec[Bar] via Codec", CodecTests[Bar](codecForBar, codecForBar).codec)
+  checkAll("Codec[Baz]", CodecTests[Baz].codec)
+  checkAll("Codec[Baz] via Codec", CodecTests[Baz](codecForBaz, codecForBaz).codec)
+  checkAll("Codec[Qux[Baz]]", CodecTests[Qux[Baz]].codec)
+  checkAll("Codec[Qux[Baz]] via Codec", CodecTests[Qux[Baz]](codecForQux, codecForQux).codec)
+
+  checkAll("Codec[User]", CodecTests[User].codec)
+  checkAll("Codec[User] via Codec", CodecTests[User](User.codecForUser, User.codecForUser).codec)
+
+  checkAll(
+    "CodecAgreementWithCodec[Foo]",
+    CodecAgreementTests[Foo](
+      codecForFoo,
+      codecForFoo,
+      decodeFoo,
+      encodeFoo
+    ).codecAgreement
+  )
+
+  checkAll(
+    "CodecAgreementWithCodec[Bar]",
+    CodecAgreementTests[Bar](
+      codecForBar,
+      codecForBar,
+      decodeBar,
+      encodeBar
+    ).codecAgreement
+  )
+
+  checkAll(
+    "CodecAgreementWithCodec[Baz]",
+    CodecAgreementTests[Baz](
+      codecForBaz,
+      codecForBaz,
+      decodeBaz,
+      encodeBaz
+    ).codecAgreement
+  )
+
+  checkAll(
+    "CodecAgreementWithCodec[Qux[Baz]]",
+    CodecAgreementTests[Qux[Baz]](
+      codecForQux,
+      codecForQux,
+      decodeQux,
+      encodeQux
+    ).codecAgreement
+  )
+
+  "deriveDecoder" should "return error when json has extra fields" in {
+    val j1 = Json.obj(
+      "first_name" -> Json.fromString("John"),
+      "last_name" -> Json.fromString("Smith"),
+      "role" -> Json.obj("TITLE" -> Json.fromString("Entrepreneur")),
+      "address" -> Json.obj(
+        "#" -> Json.fromInt(5),
+        "street" -> Json.fromString("Elm Street"),
+        "city" -> Json.fromString("Springfield"),
+        "foo" -> Json.fromString("bar")
+      )
+    )
+    val j2 = Json.obj(
+      "unexpected1" -> Json.fromInt(1),
+      "unexpected2" -> Json.fromInt(2),
+      "first_name" -> Json.fromString("John"),
+      "last_name" -> Json.fromString("Smith")
+    )
+
+    val expectedFailure1 = DecodingFailure("Unexpected field: [foo]; valid fields: #, street, city", List(CursorOp.DownField("address")))
+    val expectedFailure2 = DecodingFailure(
+      "Unexpected field: [unexpected1]; valid fields: first_name, last_name, role, address",
+      List.empty
+    )
+
+    assert(j1.as[User] === Left(expectedFailure1))
+    assert(j2.as[User] === Left(expectedFailure2))
+
+    val expectedFailureNel1 = NonEmptyList.of(
+      expectedFailure1,
+    )
+    val expectedFailureNel2 = NonEmptyList.of(
+      expectedFailure2,
+      DecodingFailure("Unexpected field: [unexpected2]; valid fields: first_name, last_name, role, address", List.empty),
+      DecodingFailure("Attempt to decode value on failed cursor", List(CursorOp.DownField("role"))),
+      DecodingFailure("Attempt to decode value on failed cursor", List(CursorOp.DownField("address")))
+    )
+
+    assert(User.decodeUser.decodeAccumulating(j1.hcursor) === Validated.invalid(expectedFailureNel1))
+    assert(User.decodeUser.decodeAccumulating(j2.hcursor) === Validated.invalid(expectedFailureNel2))
+  }
+}

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/TransformConstructorNamesSuite.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/TransformConstructorNamesSuite.scala
@@ -16,9 +16,9 @@ object TransformConstructorNamesSuite extends Serializable {
   implicit val decodeAdtQux: Decoder[AdtQux.type] = deriveDecoder
   implicit val encodeAdtQux: Encoder.AsObject[AdtQux.type] = deriveEncoder
 
-  implicit val decodeAdt: Decoder[Adt] = deriveDecoder(renaming.snakeCase, true, None)
+  implicit val decodeAdt: Decoder[Adt] = deriveDecoder(renaming.snakeCase, true, None, false)
   implicit val encodeAdt: Encoder.AsObject[Adt] = deriveEncoder(renaming.snakeCase, None)
-  val codecForAdt: Codec[Adt] = deriveCodec(renaming.snakeCase, true, None)
+  val codecForAdt: Codec[Adt] = deriveCodec(renaming.snakeCase, true, None, false)
 
   implicit val decodeNestedAdtBar: Decoder[NestedAdtBar] = deriveDecoder
   implicit val encodeNestedAdtBar: Encoder.AsObject[NestedAdtBar] = deriveEncoder
@@ -29,20 +29,20 @@ object TransformConstructorNamesSuite extends Serializable {
   implicit val decodeNestedAdtQux: Decoder[NestedAdtQux.type] = deriveDecoder
   implicit val encodeNestedAdtQux: Encoder.AsObject[NestedAdtQux.type] = deriveEncoder
 
-  implicit val decodeNestedAdt: Decoder[NestedAdt] = deriveDecoder(renaming.snakeCase, true, None)
+  implicit val decodeNestedAdt: Decoder[NestedAdt] = deriveDecoder(renaming.snakeCase, true, None, false)
   implicit val encodeNestedAdt: Encoder.AsObject[NestedAdt] = deriveEncoder(renaming.snakeCase, None)
-  val codecForNestedAdt: Codec[NestedAdt] = deriveCodec(renaming.snakeCase, true, None)
+  val codecForNestedAdt: Codec[NestedAdt] = deriveCodec(renaming.snakeCase, true, None, false)
 
   object discriminator {
     val typeField = Some("_type")
 
-    implicit val decodeAdt: Decoder[Adt] = deriveDecoder(renaming.snakeCase, true, typeField)
+    implicit val decodeAdt: Decoder[Adt] = deriveDecoder(renaming.snakeCase, true, typeField, false)
     implicit val encodeAdt: Encoder.AsObject[Adt] = deriveEncoder(renaming.snakeCase, typeField)
-    val codecForAdt: Codec[Adt] = deriveCodec(renaming.snakeCase, true, typeField)
+    val codecForAdt: Codec[Adt] = deriveCodec(renaming.snakeCase, true, typeField, false)
 
-    implicit val decodeNestedAdt: Decoder[NestedAdt] = deriveDecoder(renaming.snakeCase, true, typeField)
+    implicit val decodeNestedAdt: Decoder[NestedAdt] = deriveDecoder(renaming.snakeCase, true, typeField, false)
     implicit val encodeNestedAdt: Encoder.AsObject[NestedAdt] = deriveEncoder(renaming.snakeCase, typeField)
-    val codecForNestedAdt: Codec[NestedAdt] = deriveCodec(renaming.snakeCase, true, typeField)
+    val codecForNestedAdt: Codec[NestedAdt] = deriveCodec(renaming.snakeCase, true, typeField, false)
   }
 }
 

--- a/modules/derivation/shared/src/test/scala/io/circe/derivation/TransformMemberNamesSuite.scala
+++ b/modules/derivation/shared/src/test/scala/io/circe/derivation/TransformMemberNamesSuite.scala
@@ -7,26 +7,27 @@ import io.circe.syntax._
 import io.circe.testing.CodecTests
 
 object TransformMemberNamesSuiteCodecs extends Serializable {
-  implicit val decodeFoo: Decoder[Foo] = deriveDecoder(renaming.snakeCase, true, None)
+  implicit val decodeFoo: Decoder[Foo] = deriveDecoder(renaming.snakeCase, true, None, false)
   implicit val encodeFoo: Encoder.AsObject[Foo] = deriveEncoder(renaming.snakeCase, None)
-  val codecForFoo: Codec.AsObject[Foo] = deriveCodec(renaming.snakeCase, true, None)
+  val codecForFoo: Codec.AsObject[Foo] = deriveCodec(renaming.snakeCase, true, None, false)
 
-  implicit val decodeBar: Decoder[Bar] = deriveDecoder(renaming.snakeCase, true, None)
+  implicit val decodeBar: Decoder[Bar] = deriveDecoder(renaming.snakeCase, true, None, false)
   implicit val encodeBar: Encoder.AsObject[Bar] = deriveEncoder(renaming.snakeCase, None)
-  val codecForBar: Codec.AsObject[Bar] = deriveCodec(renaming.snakeCase, true, None)
+  val codecForBar: Codec.AsObject[Bar] = deriveCodec(renaming.snakeCase, true, None, false)
 
-  implicit val decodeBaz: Decoder[Baz] = deriveDecoder(renaming.snakeCase, true, None)
+  implicit val decodeBaz: Decoder[Baz] = deriveDecoder(renaming.snakeCase, true, None, false)
   implicit val encodeBaz: Encoder.AsObject[Baz] = deriveEncoder(renaming.snakeCase, None)
-  val codecForBaz: Codec.AsObject[Baz] = deriveCodec(renaming.snakeCase, true, None)
+  val codecForBaz: Codec.AsObject[Baz] = deriveCodec(renaming.snakeCase, true, None, false)
 
   implicit def decodeQux[A: Decoder]: Decoder[Qux[A]] =
-    deriveDecoder(renaming.replaceWith("aa" -> "1", "bb" -> "2"), true, None)
+    deriveDecoder(renaming.replaceWith("aa" -> "1", "bb" -> "2"), true, None, false)
   implicit def encodeQux[A: Encoder]: Encoder.AsObject[Qux[A]] =
     deriveEncoder(renaming.replaceWith("aa" -> "1", "bb" -> "2"), None)
   def codecForQux[A: Decoder: Encoder]: Codec.AsObject[Qux[A]] = deriveCodec(
     renaming.replaceWith("aa" -> "1", "bb" -> "2"),
     true,
-    None
+    None,
+    false
   )
 }
 


### PR DESCRIPTION
This PR implements "strict" decoding as is provided by [circe-generic-extras](https://github.com/circe/circe-generic-extras). By default strict decoding is off. When strict decoding is enabled, any extra fields that aren't expected to be decoded will be raised as decoding errors.